### PR TITLE
Search URL has 10.6 hardcoded, Fails.

### DIFF
--- a/IBM/BigFixAgent.download.recipe
+++ b/IBM/BigFixAgent.download.recipe
@@ -36,7 +36,7 @@
                 <key>url</key>
                 <string>%SEARCH_URL%/%latest_release_path%</string>
                 <key>re_pattern</key>
-                <string><![CDATA[(?P<url>http://software\.bigfix\.com/download/bes/[0-9]+/BESAgent-(?P<version>[0-9.]+)-BigFix_MacOSX10.6.pkg)]]></string>
+                <string><![CDATA[(?P<url>http://software\.bigfix\.com/download/bes/[0-9]+/BESAgent-(?P<version>[0-9.]+)-BigFix_MacOSX10.7.pkg)]]></string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
And the latest from IBM is 10.7 e.g. "BESAgent-9.5.1.9-BigFix_MacOSX10.7.pkg"  Might be better to use "MacOSX10.[0-9]+.pkg" to future-proof it, but this works now (tested).

M@
